### PR TITLE
Add error bubbling of deploy-cloudconfig

### DIFF
--- a/main.go
+++ b/main.go
@@ -94,7 +94,11 @@ func main() {
 			Subcommands: utils.GetProductCommands(ProductPluginsDir),
 		},
 	}
-	app.Run(os.Args)
+	err := app.Run(os.Args)
+	if err != nil {
+		fmt.Println("ERROR:", err)
+		os.Exit(1)
+	}
 }
 
 func init() {


### PR DESCRIPTION
Ensure errors and bad http responses bubble up to the user instead of silently failing.