### PR TITLE
Check env variable for cloudconfig networks

### DIFF
--- a/plugins/cloudconfigs/base_cloudconfig.go
+++ b/plugins/cloudconfigs/base_cloudconfig.go
@@ -106,7 +106,7 @@ func CreateNetworks(context *cli.Context, validateCloudPropertiesFunction func(i
 	for i := 1; i <= SupportedNetworkCount; i++ {
 		networkFlag := fmt.Sprintf("network-name-%d", i)
 		networkName := context.String(networkFlag)
-		if !context.IsSet(networkFlag) {
+		if !context.IsSet(networkFlag) && networkName == "" {
 			continue
 		}
 


### PR DESCRIPTION
Fixes that if a network was set using environment variables that OMG wouldn't recognize there being a valid network